### PR TITLE
Skip checking if key exists in parent state

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -314,9 +314,7 @@ var SimpleStorage = function (_Component) {
 
           // update parent's state with the result
           // store.js handles parsing
-          if (name in parent.state) {
-            parent.setState(_defineProperty({}, name, value));
-          }
+          parent.setState(_defineProperty({}, name, value));
         }
       });
 

--- a/src/index.js
+++ b/src/index.js
@@ -76,9 +76,7 @@ export default class SimpleStorage extends Component {
 
         // update parent's state with the result
         // store.js handles parsing
-				if (name in parent.state) {
-				  parent.setState({ [name]: value });
-				}
+        parent.setState({ [name]: value });
       }
     });
 


### PR DESCRIPTION
We have some state that starts off as undefined and later gets filled by user interaction. Currently, this state is not synced with storage because of a check that checks if the parent state contains a key before syncing it. This PR removes that check.

I don't see any downsides to not having the check but I'm open for discussion if you think the check should stay =)